### PR TITLE
fix: change header contents layout depending on screen ratio

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -47,7 +47,7 @@ const Header = (props: HeaderProps) => {
     return (
         <>
             <AppBar position="sticky" sx={{ background: "transparent", boxShadow: "none", padding: "10px", width: '100vw', mb: "10px" }}>
-                <Toolbar style={{justifyContent: "space-between"}}>
+                <Toolbar style={{ justifyContent: props.isMobile ? "space-between" : "center" }}>
                     <Avatar
                         alt="logo"
                         src="/assets/j-logo.png"


### PR DESCRIPTION
Use `space-between` when ratio is portrait so that the menu icon is snug on the right. Use `center` when in landscape so that the logo and tabs are centered.